### PR TITLE
Fix race

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,40 @@
+use crate::config::Config;
+use serenity::{
+  async_trait,
+  model::{channel::Message, gateway::Ready},
+  prelude::*,
+};
+
+mod ready;
 mod reddit_prev;
 mod shrug;
 
-pub use reddit_prev::RedditPreviewHandler;
-pub use shrug::ShrugHandler;
+pub struct Handler {
+  ready: ready::ReadyHandler,
+  shrug: shrug::ShrugHandler,
+  reddit: reddit_prev::RedditPreviewHandler,
+}
+
+impl Handler {
+  pub fn new(config: Config) -> Self {
+    Handler {
+      ready: ready::ReadyHandler::new(),
+      shrug: shrug::ShrugHandler::new(config.clone()),
+      reddit: reddit_prev::RedditPreviewHandler::new(),
+    }
+  }
+}
+
+#[async_trait]
+impl EventHandler for Handler {
+  async fn message(&self, ctx: Context, msg: Message) {
+    tokio::join!(
+      self.shrug.message(&ctx, &msg),
+      self.reddit.message(&ctx, &msg),
+    );
+  }
+
+  async fn ready(&self, ctx: Context, rdy: Ready) {
+    self.ready.ready(&ctx, &rdy).await
+  }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::debug::Debug;
 use serenity::{
   async_trait,
   model::{channel::Message, gateway::Ready},
@@ -17,10 +18,11 @@ pub struct Handler {
 
 impl Handler {
   pub fn new(config: Config) -> Self {
+    let debug = Debug::new(config.clone());
     Handler {
       ready: ready::ReadyHandler::new(),
-      shrug: shrug::ShrugHandler::new(config.clone()),
-      reddit: reddit_prev::RedditPreviewHandler::new(),
+      shrug: shrug::ShrugHandler::new(config.clone(), debug.clone()),
+      reddit: reddit_prev::RedditPreviewHandler::new(debug.clone()),
     }
   }
 }

--- a/src/cmd/ready.rs
+++ b/src/cmd/ready.rs
@@ -1,0 +1,13 @@
+use serenity::{model::gateway::Ready, prelude::Context};
+
+pub struct ReadyHandler {}
+
+impl ReadyHandler {
+  pub fn new() -> Self {
+    ReadyHandler {}
+  }
+
+  pub async fn ready(&self, _: &Context, ready: &Ready) {
+    println!("{} is connected!", ready.user.name);
+  }
+}

--- a/src/cmd/reddit_prev.rs
+++ b/src/cmd/reddit_prev.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use reqwest::Client;
 use select::document::Document;
 use select::predicate::Class;
-use serenity::{async_trait, model::channel::Message, prelude::*};
+use serenity::{model::channel::Message, prelude::Context};
 
 pub struct RedditPreviewHandler {}
 
@@ -34,11 +34,8 @@ impl RedditPreviewHandler {
       .attr("href")?;
     Some(val.to_owned())
   }
-}
 
-#[async_trait]
-impl EventHandler for RedditPreviewHandler {
-  async fn message(&self, ctx: Context, msg: Message) {
+  pub async fn message(&self, ctx: &Context, msg: &Message) {
     if msg.is_own(&ctx.cache).await {
       return;
     }

--- a/src/cmd/shrug.rs
+++ b/src/cmd/shrug.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::debug::Debug;
 use serenity::{
   cache::Cache,
   model::{channel::Message, channel::ReactionType, guild::Emoji, id::GuildId},
@@ -7,19 +8,12 @@ use serenity::{
 
 pub struct ShrugHandler {
   config: Config,
+  debug: Debug,
 }
 
 impl ShrugHandler {
-  pub fn new(config: Config) -> Self {
-    ShrugHandler { config }
-  }
-}
-
-impl ShrugHandler {
-  fn debug(&self, msg: &str) {
-    if self.config.get_env().is_dev() {
-      println!("{}", msg);
-    }
+  pub fn new(config: Config, debug: Debug) -> Self {
+    ShrugHandler { config, debug }
   }
 
   async fn pull_emoji(&self, guild_id: GuildId, cache: &Cache) -> Result<Emoji, String> {
@@ -61,7 +55,7 @@ impl ShrugHandler {
 
   pub async fn message(&self, ctx: &Context, msg: &Message) {
     if msg.is_own(&ctx.cache).await {
-      self.debug("Skipping, self message");
+      self.debug.log("Skipping, self message");
       return;
     }
 
@@ -79,7 +73,7 @@ impl ShrugHandler {
     });
 
     if mentions_user.is_none() {
-      self.debug("Did not find a matching user mention");
+      self.debug.log("Did not find a matching user mention");
       return;
     }
 

--- a/src/cmd/shrug.rs
+++ b/src/cmd/shrug.rs
@@ -1,10 +1,8 @@
 use crate::config::Config;
-
 use serenity::{
-  async_trait,
   cache::Cache,
-  model::{channel::Message, channel::ReactionType, gateway::Ready, guild::Emoji, id::GuildId},
-  prelude::*,
+  model::{channel::Message, channel::ReactionType, guild::Emoji, id::GuildId},
+  prelude::Context,
 };
 
 pub struct ShrugHandler {
@@ -18,6 +16,12 @@ impl ShrugHandler {
 }
 
 impl ShrugHandler {
+  fn debug(&self, msg: &str) {
+    if self.config.get_env().is_dev() {
+      println!("{}", msg);
+    }
+  }
+
   async fn pull_emoji(&self, guild_id: GuildId, cache: &Cache) -> Result<Emoji, String> {
     // Pull the emoji from the guild attached to the message
     let maybe_emoji = cache
@@ -54,12 +58,10 @@ impl ShrugHandler {
       .map(|_| ())
       .map_err(|_| "Failed to react/Send".to_string())
   }
-}
 
-#[async_trait]
-impl EventHandler for ShrugHandler {
-  async fn message(&self, ctx: Context, msg: Message) {
+  pub async fn message(&self, ctx: &Context, msg: &Message) {
     if msg.is_own(&ctx.cache).await {
+      self.debug("Skipping, self message");
       return;
     }
 
@@ -76,8 +78,8 @@ impl EventHandler for ShrugHandler {
         .any(|cname| *cname.to_lowercase() == user.name.to_lowercase())
     });
 
-    if (mentions_user.is_none()) {
-      // Nothing to do here
+    if mentions_user.is_none() {
+      self.debug("Did not find a matching user mention");
       return;
     }
 
@@ -102,9 +104,5 @@ impl EventHandler for ShrugHandler {
         }
       }
     }
-  }
-
-  async fn ready(&self, _: Context, ready: Ready) {
-    println!("{} is connected!", ready.user.name);
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::Environment;
 use std::{env, env::VarError};
 
 #[derive(Debug, Clone)]
@@ -5,10 +6,11 @@ pub struct Config {
   api_key: String,
   emote_name: String,
   emote_users: Vec<String>,
+  env: Environment,
 }
 
 impl Config {
-  pub fn new() -> Result<Config, VarError> {
+  pub fn new(env: Environment) -> Result<Config, VarError> {
     Ok(Config {
       api_key: env::var("API_KEY")?,
       emote_name: env::var("EMOTE_NAME")?,
@@ -16,6 +18,7 @@ impl Config {
         .split(",")
         .map(|x| x.to_string())
         .collect(),
+      env,
     })
   }
 
@@ -29,5 +32,9 @@ impl Config {
 
   pub fn get_emote_users(&self) -> &Vec<String> {
     &self.emote_users
+  }
+
+  pub fn get_env(&self) -> &Environment {
+    &self.env
   }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,18 @@
+use crate::config::Config;
+
+#[derive(Clone)]
+pub struct Debug {
+  config: Config,
+}
+
+impl Debug {
+  pub fn new(config: Config) -> Self {
+    Debug { config }
+  }
+
+  pub fn log(&self, msg: &str) {
+    if self.config.get_env().is_dev() {
+      println!("{}", msg);
+    }
+  }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+#[derive(Clone, Debug, PartialEq)]
 pub enum Environment {
   PROD,
   DEV,
@@ -11,6 +12,10 @@ impl Environment {
       Environment::PROD => String::from("prod.env"),
       Environment::DEV => String::from("dev.env"),
     }
+  }
+
+  pub fn is_dev(&self) -> bool {
+    self == &Environment::DEV
   }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 
 use serenity::{client::bridge::gateway::GatewayIntents, prelude::*};
 
-use cmd::{RedditPreviewHandler, ShrugHandler};
+use cmd::Handler;
 use config::Config;
 use env::Environment;
 
@@ -23,7 +23,7 @@ async fn main() {
     Environment::from_str(&v).unwrap()
   });
   dotenv::from_filename(env.as_file()).ok();
-  let config = Config::new().expect("Err parsing environment");
+  let config = Config::new(env).expect("Err parsing environment");
 
   let mut client = Client::builder(&config.get_api_key())
     .intents(
@@ -32,8 +32,7 @@ async fn main() {
         | GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::GUILD_MESSAGE_REACTIONS,
     )
-    .event_handler(ShrugHandler::new(config.clone()))
-    .event_handler(RedditPreviewHandler::new())
+    .event_handler(Handler::new(config))
     .await
     .expect("Err creating client");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ extern crate select;
 
 mod cmd;
 mod config;
+mod debug;
 mod env;
 
 use std::str::FromStr;
@@ -24,7 +25,6 @@ async fn main() {
   });
   dotenv::from_filename(env.as_file()).ok();
   let config = Config::new(env).expect("Err parsing environment");
-
   let mut client = Client::builder(&config.get_api_key())
     .intents(
       GatewayIntents::GUILDS
@@ -32,7 +32,7 @@ async fn main() {
         | GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::GUILD_MESSAGE_REACTIONS,
     )
-    .event_handler(Handler::new(config))
+    .event_handler(Handler::new(config.clone()))
     .await
     .expect("Err creating client");
 


### PR DESCRIPTION
Multiple event handlers are not supported in serenity, so there was a race to which actually took effect (it appeared to not be the last passed event_handler, but an actual race...)

Refactored handlers into delegates, `cmd` mod now joins them all together.