### PR TITLE
Fixed race where bot disconnects while queuing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "hex",
  "humantime",
  "lazy_static",
+ "once_cell",
  "openssl",
  "rand 0.8.4",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ dotenv = "0.15.0"
 hex = "0.4.3"
 humantime = "2.1.0"
 lazy_static = "1.4.0"
+once_cell = "1.8.0"
 openssl = { version = "0.10.35", features = ["vendored"] }
 rand = "0.8.2"
 regex = "1"

--- a/src/cmd/voice/connect_util.rs
+++ b/src/cmd/voice/connect_util.rs
@@ -1,5 +1,4 @@
-use std::{sync::Arc, time::Duration};
-
+use once_cell::sync::Lazy;
 use serenity::{
   async_trait,
   http::Http,
@@ -12,11 +11,17 @@ use serenity::{
   FutureExt,
 };
 use songbird::{Call, Event, EventContext, EventHandler, Songbird};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::mpsc::{self, Receiver, Sender};
 use tracing::{info, instrument};
 
-lazy_static! {
-  static ref HANDLER_ADDED: RwLock<bool> = RwLock::new(false);
-}
+static HANDLER_ADDED: Lazy<RwLock<bool>> = Lazy::new(|| RwLock::new(false));
+static CHAN: Lazy<(Sender<bool>, Mutex<Receiver<bool>>)> = Lazy::new(|| {
+  let (sd, rc) = mpsc::channel(32);
+  (sd, Mutex::new(rc))
+});
+static IN_PROG_COUNT: Lazy<Mutex<usize>> = Lazy::new(|| Mutex::new(0));
+const TIMEOUT_SECS: u64 = 600;
 
 #[derive(Builder, Clone)]
 pub struct ChannelDisconnect {
@@ -28,19 +33,38 @@ pub struct ChannelDisconnect {
 }
 
 impl ChannelDisconnect {
+  pub fn get_chan() -> Sender<bool> {
+    CHAN.0.clone()
+  }
+
   pub async fn maybe_register_handler(&self, handler_lock: &Arc<Mutex<Call>>) {
     if !HANDLER_ADDED.read().map(|g| *g).await {
       let _fut = HANDLER_ADDED.write().map(|mut g| *g = true).await;
       let mut handler = handler_lock.lock().await;
       handler.add_global_event(
-        Event::Periodic(Duration::from_secs(300), None),
+        Event::Periodic(Duration::from_secs(TIMEOUT_SECS), None),
         self.clone(),
       );
+      tokio::spawn(async move {
+        loop {
+          match CHAN.1.lock().await.recv().await {
+            Some(true) => *(IN_PROG_COUNT.lock().await) += 1,
+            Some(false) => *(IN_PROG_COUNT.lock().await) -= 1,
+            None => (),
+          }
+        }
+      });
     }
   }
 
   pub async fn stop(&self) {
     let _dis = self.disconnect(true).await;
+  }
+
+  async fn is_queuing(&self) -> bool {
+    let count = *IN_PROG_COUNT.lock().await;
+    info!("Checking for in prog: {}", count);
+    count > 0
   }
 
   async fn disconnect(&self, force: bool) {
@@ -58,7 +82,7 @@ impl ChannelDisconnect {
           true
         } else {
           info!("Checking queue prescense");
-          handler.queue().is_empty()
+          handler.queue().is_empty() && !self.is_queuing().await
         }
       }
     };

--- a/src/cmd/voice/mod.rs
+++ b/src/cmd/voice/mod.rs
@@ -16,7 +16,7 @@ use stop::*;
 #[group]
 #[description = "Stream sound to the channel"]
 #[summary = "Sheebs Givith Loud Noises"]
-#[prefixes("p","play")]
+#[prefixes("p", "play")]
 #[only_in(guilds)]
 #[default_command(play)]
 #[commands(skip, stop, list, reorder)]

--- a/src/cmd/voice/play.rs
+++ b/src/cmd/voice/play.rs
@@ -13,11 +13,17 @@ use songbird::{
   input::{restartable::Restartable, Input},
 };
 
+use super::connect_util::ChannelDisconnect;
+
 #[command]
 #[description = "Play a sound clip via link or search term"]
 #[only_in(guilds)]
 async fn play(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
-  exec_play(ctx, msg, args).await
+  let chan = ChannelDisconnect::get_chan();
+  let _ = chan.send(true).await;
+  let res = exec_play(ctx, msg, args).await;
+  let _ = chan.send(false).await;
+  res
 }
 
 #[instrument(name = "VoicePlay", level = "INFO", skip(ctx, msg, args))]


### PR DESCRIPTION
Due to long queue times as sources buffer from YTDL, the bot may
disconnect if the queue is sitting empty while the next item is still
being enqueued. Since we can't speed up queue times we have two options:
Add the bot back into the channel right before queuing (this is too late)
or add a signal to the disconnect handler which informs if a queue is in
progress. We've gone with the latter in this PR.

Addresses https://github.com/dfontana/disbot/issues/42