### PR TITLE
Fixes Image Regex for Post/CommentId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,8 +1888,8 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.11.1"
-source = "git+https://github.com/serenity-rs/serenity?rev=c83ba2a1d61bf8e29638da26bab9f94dd0d90c0f#c83ba2a1d61bf8e29638da26bab9f94dd0d90c0f"
+version = "0.11.2"
+source = "git+https://github.com/serenity-rs/serenity?rev=502fc8d6515d960fdb064acb1893c2d8f4e4efe9#502fc8d6515d960fdb064acb1893c2d8f4e4efe9"
 dependencies = [
  "async-trait",
  "async-tungstenite 0.17.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = { version = "0.11", features = ["json"] }
 select = "0.5.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0"
-serenity = {default-features = false, features = ["client", "cache", "gateway", "model","rustls_backend","unstable_discord_api", "voice"], version="0.11.1"}
+serenity = {default-features = false, features = ["client", "cache", "gateway", "model","rustls_backend","unstable_discord_api", "voice"], version="0.11.2"}
 songbird = {features = ["builtin-queue", "yt-dlp"], version="0.2.2"}
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.28"
@@ -40,5 +40,5 @@ test-case = "2.0.2"
 [patch.crates-io]
 # Need to patch since songbird pulls in a version, we need to make the same
 # Can go away once we're back on an official version number and not git
-serenity = {git="https://github.com/serenity-rs/serenity", rev="c83ba2a1d61bf8e29638da26bab9f94dd0d90c0f"}
+serenity = {git="https://github.com/serenity-rs/serenity", rev="502fc8d6515d960fdb064acb1893c2d8f4e4efe9"}
 songbird = {git="https://github.com/dfontana/songbird", rev="92cf1b4b0047120fcc3d88b8fded7ea0a2d8db32"}

--- a/src/cmd/reddit_prev.rs
+++ b/src/cmd/reddit_prev.rs
@@ -19,9 +19,9 @@ static REDDIT_LINK: Lazy<Regex> = Lazy::new(|| {
         www.reddit.com            # is reddit.com
         /r/[^\s]+/                # skip over the subreddit
         comments/                 # post-id comes after this    
-        (?P<postid>[a-z1-9]+)     # capture postid
+        (?P<postid>[a-z0-9]+)     # capture postid
         (?:/comment/)*            # maybe will be a comment
-        (?P<commentid>[a-z1-9]+)? # capture comment id if it's there
+        (?P<commentid>[a-z0-9]+)? # capture comment id if it's there
       )
     ",
   )

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ async fn main() {
     GatewayIntents::GUILDS
       | GatewayIntents::GUILD_EMOJIS_AND_STICKERS
       | GatewayIntents::GUILD_MESSAGES
+      | GatewayIntents::MESSAGE_CONTENT
       | GatewayIntents::GUILD_MESSAGE_REACTIONS
       | GatewayIntents::GUILD_VOICE_STATES,
   )


### PR DESCRIPTION
Which was previously ignoring "0" erroneously, causing post ids to
terminate prematurely and thus breaking functionality when selecting
images.

Additionally I've bumped Serenity RS version and added an additional
intent that will become necessary on Aug 31 2022.

Addresses #57 