### PR TITLE
Switch x86_64 target to musl for static builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For ArmV7 (eg Raspberry Pi) or `x86_64` Linux (eg Linux Server).
   - Uses [`messense/homebrew-macos-cross-toolchains`](https://github.com/messense/homebrew-macos-cross-toolchains)
   ```
   brew tap messense/macos-cross-toolchains
-  brew install armv7-unknown-linux-gnueabihf x86_64-unknown-linux-gnu
+  brew install armv7-unknown-linux-gnueabihf x86_64-unknown-linux-musl
   ./bin/build_for_arm
   ./bin/build_for_x86_64
   ```
@@ -56,7 +56,7 @@ voice_channel_timeout_seconds = 600
 # You can repeat this for dev.toml as well
 ```
 
-1. `ARCH={armv7-unknown-linux-gnueabihf|x86_64-unknown-linux-gnu} ./bin/deploy {dev|prod} {server.local|raspberrypi.local}`
+1. `ARCH={armv7-unknown-linux-gnueabihf|x86_64-unknown-linux-musl} ./bin/deploy {dev|prod} {server.local|raspberrypi.local}`
   - You can use github to download a release made in CI with `BUILD_GITHUB=1`
   - Otherwise this will detect the correct way to build from your host system
   - Uses user services (no sudo password prompts during deployment)

--- a/bin/build_for_x86_64
+++ b/bin/build_for_x86_64
@@ -1,12 +1,16 @@
 #!/bin/bash
 # Cross compile to linux x86_64; should run from root of repo
-TARGET=x86_64-unknown-linux-gnu
+TARGET=x86_64-unknown-linux-musl
 export TARGET_CC=$TARGET-gcc
 export TARGET_AR=$TARGET-ar
-export CC_x86_64_unknown_linux_gnu=$TARGET-gcc
-export CXX_x86_64_unknown_linux_gnu=$TARGET-g++
-export AR_x86_64_unknown_linux_gnu=$TARGET-ar
-export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=$TARGET-gcc
-export CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_gnu=$(pwd)/bin/x86_64.cmake
-export CMAKE_x86_64_unknown_linux_gnu=$(pwd)/bin/cmake-wrapper
-RUSTFLAGS="-Awarnings -C link-args=-fstack-protector-all -lssp" cargo build --quiet --release --target $TARGET
+export CC_x86_64_unknown_linux_musl=$TARGET-gcc
+export CXX_x86_64_unknown_linux_musl=$TARGET-g++
+export AR_x86_64_unknown_linux_musl=$TARGET-ar
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=$TARGET-gcc
+export CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_musl=$(pwd)/bin/x86_64.cmake
+export CMAKE_x86_64_unknown_linux_musl=$(pwd)/bin/cmake-wrapper
+
+# Static linking setup for musl
+export RUSTFLAGS="-C target-feature=+crt-static"
+
+cargo build --quiet --release --target $TARGET

--- a/bin/deploy
+++ b/bin/deploy
@@ -5,7 +5,7 @@
 #     For RPi on ARM Machine: ./bin/deploy prod           (Cross compiles with native tools & sends to raspberrypi.local)
 #     For RPi CI Machine BUILD_GITHUB=1 ./bin/deploy prod (Cross compiles on Github Action & sends to raspberrypi.local)
 #   x86 Linux Deploy:
-#     ARCH=x86_64-unknown-linux-gnu ./bin/deploy prod server.local
+#     ARCH=x86_64-unknown-linux-musl ./bin/deploy prod server.local
 #
 set -e
 

--- a/bin/x86_64.cmake
+++ b/bin/x86_64.cmake
@@ -1,5 +1,5 @@
 set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSROOT /opt/homebrew/Cellar/x86_64-unknown-linux-gnu/13.3.0/toolchain/x86_64-unknown-linux-gnu/sysroot/)
+set(CMAKE_SYSROOT /opt/homebrew/Cellar/x86_64-unknown-linux-musl/13.3.0/toolchain/x86_64-unknown-linux-musl/sysroot/)
 set(tools /opt/homebrew/bin)
-set(CMAKE_C_COMPILER /opt/homebrew/bin/x86_64-unknown-linux-gnu-gcc)
-set(CMAKE_CXX_COMPILER /opt/homebrew/bin/x86_64-unknown-linux-gnu-g++)
+set(CMAKE_C_COMPILER /opt/homebrew/bin/x86_64-unknown-linux-musl-gcc)
+set(CMAKE_CXX_COMPILER /opt/homebrew/bin/x86_64-unknown-linux-musl-g++)


### PR DESCRIPTION
## Summary
• Switches x86_64 Linux target from `x86_64-unknown-linux-gnu` to `x86_64-unknown-linux-musl`
• Enables static linking with `RUSTFLAGS="-C target-feature=+crt-static"`
• Updates cross-compilation toolchain references and deployment scripts
• Removes stack protector flags that were causing build issues with musl

This change produces fully static binaries that don't depend on system glibc, improving deployment compatibility across different Linux distributions.

🤖 Generated with [Claude Code](https://claude.ai/code)