### PR TITLE
Add configurable web server IP binding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,7 @@ dependencies = [
  "hex",
  "humantime",
  "itertools",
+ "local-ip-address",
  "once_cell",
  "openssl",
  "rand 0.9.1",
@@ -1776,6 +1777,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror 2.0.12",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,6 +1906,31 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bollard = "0.19.1"
 anyhow = "1.0.86"
 axum = "0.8"
 clap = { version = "4.0", features = ["derive"] }
+local-ip-address = "0.6"
 toml = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,23 @@ use env::Environment;
 use persistence::PersistentStore;
 use std::sync::Arc;
 
+#[derive(Debug, Clone)]
+pub enum WebBindAddress {
+  Lan,
+  Ip(String),
+}
+
+impl std::str::FromStr for WebBindAddress {
+  type Err = String;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "lan" => Ok(WebBindAddress::Lan),
+      ip => Ok(WebBindAddress::Ip(ip.to_string())),
+    }
+  }
+}
+
 #[derive(Parser)]
 #[command(name = "disbot")]
 #[command(about = "Discord bot with admin web interface")]
@@ -54,7 +71,7 @@ struct Cli {
 
   /// Web server bind address (IP address, "lan" for LAN IP, or "0.0.0.0" for all interfaces)
   #[arg(long, default_value = "0.0.0.0")]
-  web_bind_address: String,
+  web_bind_address: WebBindAddress,
 }
 
 // Global handle for runtime log level changes

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,10 @@ struct Cli {
   /// Web server port
   #[arg(short, long, default_value = "3450")]
   port: u16,
+
+  /// Web server bind address (IP address, "lan" for LAN IP, or "0.0.0.0" for all interfaces)
+  #[arg(long, default_value = "0.0.0.0")]
+  web_bind_address: String,
 }
 
 // Global handle for runtime log level changes
@@ -169,7 +173,12 @@ async fn main() {
   // Persistence restoration happens in the ready event handler where actor handles are available
 
   // Start web server and Discord client concurrently
-  let web_server = web::start_server(final_config_path, persistence.clone(), cli.port);
+  let web_server = web::start_server(
+    final_config_path,
+    persistence.clone(),
+    cli.web_bind_address,
+    cli.port,
+  );
   let discord_client = client.start();
 
   tokio::select! {


### PR DESCRIPTION
## Summary
- Implements configurable IP binding for the web server via `--web-bind-address` CLI argument
- Supports specific IP addresses, "lan" for automatic LAN IP detection, and "0.0.0.0" for all interfaces (default)
- Maintains backward compatibility with existing behavior

## Test plan
- [x] Test default behavior (binds to 0.0.0.0)
- [x] Test localhost binding (--web-bind-address 127.0.0.1)
- [x] Test LAN IP detection (--web-bind-address lan)
- [x] Verify graceful fallback when LAN detection fails
- [x] Run cargo build, clippy, fmt, and tests
- [x] Confirm all existing functionality works unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)