### PR TITLE
Fix clippy large_enum_variant warnings

### DIFF
--- a/src/cmd/check_in/actor.rs
+++ b/src/cmd/check_in/actor.rs
@@ -120,7 +120,7 @@ impl Actor<CheckInMessage> for CheckInActor {
         let nw_ctx = ctx.clone();
         self
           .poll_handle
-          .send(PollMessage::CreatePoll((ctx.into(), chan)))
+          .send(PollMessage::CreatePoll(Box::new((ctx.into(), chan))))
           .await;
         let sleep_until = time_until(Utc::now(), nw_ctx.poll_time);
         self

--- a/src/cmd/poll/actor.rs
+++ b/src/cmd/poll/actor.rs
@@ -18,8 +18,8 @@ use super::{cache::Cache, messages, pollstate::PollState};
 
 #[derive(Clone)]
 pub enum PollMessage {
-  UpdateVote((Uuid, String, Context, ComponentInteraction)),
-  CreatePoll((PollState, ChannelId)),
+  UpdateVote(Box<(Uuid, String, Context, ComponentInteraction)>),
+  CreatePoll(Box<(PollState, ChannelId)>),
   ExpirePoll(Uuid),
   RestorePolls(Arc<serenity::http::Http>),
 }
@@ -54,7 +54,8 @@ impl Actor<PollMessage> for PollActor {
 
   async fn handle_msg(&mut self, msg: PollMessage) {
     match msg {
-      PollMessage::CreatePoll((ps, itx)) => {
+      PollMessage::CreatePoll(boxed_data) => {
+        let (ps, itx) = *boxed_data;
         let exp = ps.duration;
         let exp_key = ps.id;
 
@@ -103,7 +104,8 @@ impl Actor<PollMessage> for PollActor {
           );
         }
       }
-      PollMessage::UpdateVote((id, voter, ctx, mtx)) => {
+      PollMessage::UpdateVote(boxed_data) => {
+        let (id, voter, ctx, mtx) = *boxed_data;
         let votes = match mtx.data.kind {
           ComponentInteractionDataKind::StringSelect { ref values } => values,
           _ => {

--- a/src/cmd/poll/command.rs
+++ b/src/cmd/poll/command.rs
@@ -119,7 +119,7 @@ impl Poll {
       .get(&ctx.http, &ctx.cache, guild_id)
       .await
       .and_then(|emoji| PollState::from_args(ctx, emoji, itx))
-      .map(|ps| PollMessage::CreatePoll((ps, itx.channel_id)))?;
+      .map(|ps| PollMessage::CreatePoll(Box::new((ps, itx.channel_id))))?;
     self.actor.send(pm).await;
     let _ = itx
       .create_response(
@@ -145,12 +145,12 @@ impl Poll {
 
     self
       .actor
-      .send(PollMessage::UpdateVote((
+      .send(PollMessage::UpdateVote(Box::new((
         poll_id,
         user,
         ctx.clone(),
         itx.clone(),
-      )))
+      ))))
       .await;
     Ok(())
   }


### PR DESCRIPTION
## Summary

- Fix clippy `large_enum_variant` warnings in `PollMessage` enum by boxing large variants
- Reduced enum size from 920 bytes to under the threshold
- Updated all call sites and pattern matching to handle boxed values

## Changes

- **UpdateVote variant**: Box large tuple containing `(Uuid, String, Context, ComponentInteraction)`
- **CreatePoll variant**: Box tuple containing `(PollState, ChannelId)`
- Updated pattern matching in `handle_msg` to destructure boxed values
- Updated all call sites in `command.rs` and `check_in/actor.rs` to use `Box::new()`

## Test plan

- [x] `cargo build` - Compiles successfully
- [x] `cargo test` - All 21 tests pass
- [x] `cargo clippy` - No warnings
- [x] `cargo fmt` - Formatted

🤖 Generated with [Claude Code](https://claude.ai/code)