### PR TITLE
Move Logging Init to Own Module

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use crate::Environment;
+use crate::{logging, Environment};
 use std::sync::RwLock;
 use std::time::Duration;
 use std::{fs, path::Path};
@@ -110,7 +110,7 @@ impl Config {
         .log_level
         .parse::<tracing::Level>()
         .map_err(|_| ())
-        .and_then(|level| crate::set_log_level(level).map_err(|_| ()))
+        .and_then(|level| logging::set_log_level(level).map_err(|_| ()))
         .unwrap_or_else(|_| warn!("Failed to update runtime log level"));
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,43 @@
+use anyhow::{anyhow, bail};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use tracing::Level;
+use tracing_error::ErrorLayer;
+use tracing_subscriber::{
+  filter::LevelFilter,
+  fmt::Layer,
+  prelude::*,
+  reload::{self, Handle},
+  Registry,
+};
+
+// Global handle for runtime log level changes
+static LOG_RELOAD_HANDLE: Lazy<Mutex<Option<Handle<LevelFilter, Registry>>>> =
+  Lazy::new(|| Mutex::new(None));
+
+pub fn set_log_level(level: Level) -> Result<(), anyhow::Error> {
+  let handle_guard = LOG_RELOAD_HANDLE
+    .lock()
+    .map_err(|e| anyhow!("Lock error: {}", e))?;
+  if let Some(handle) = handle_guard.as_ref() {
+    handle
+      .modify(|filter| *filter = LevelFilter::from_level(level))
+      .map_err(|e| anyhow!("Failed to update log level: {}", e))?;
+    Ok(())
+  } else {
+    bail!("Log reload handle not initialized")
+  }
+}
+
+pub fn initalize_logging() {
+  let (filter, reload_handle) = reload::Layer::new(LevelFilter::from_level(Level::INFO));
+  {
+    let mut handle_guard = LOG_RELOAD_HANDLE.lock().unwrap();
+    *handle_guard = Some(reload_handle);
+  }
+  tracing_subscriber::Registry::default()
+    .with(filter)
+    .with(Layer::default().with_target(false))
+    .with(ErrorLayer::default())
+    .init();
+}


### PR DESCRIPTION
To free up space inside main, since it's now non-trivial enough to
justify.
