### PR TITLE
Swap to Bincode Serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,12 +273,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -586,19 +580,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,25 +643,6 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -854,19 +816,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling 0.10.2",
- "derive_builder_core 0.9.0",
+ "derive_builder_core",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
 ]
 
 [[package]]
@@ -879,28 +832,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core 0.20.2",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -963,12 +894,11 @@ dependencies = [
  "chrono-tz",
  "clap",
  "derive-new",
- "derive_builder 0.20.2",
  "derive_more 2.0.1",
  "hex",
  "humantime",
  "humantime-serde",
- "itertools 0.14.0",
+ "itertools",
  "local-ip-address",
  "once_cell",
  "openssl",
@@ -983,7 +913,6 @@ dependencies = [
  "symphonia",
  "tempfile",
  "test-case",
- "tokenizers",
  "tokio",
  "tokio-util",
  "toml",
@@ -992,7 +921,6 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
- "urlencoding",
  "uuid",
 ]
 
@@ -1030,12 +958,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,15 +980,6 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "esaxx-rs"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1410,7 +1323,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b906521a5b0e6d2ec07ea0bb855d92a1db30b48812744a645a3b2a1405cb8159"
 dependencies = [
- "derive_builder 0.9.0",
+ "derive_builder",
  "derive_more 0.99.20",
  "hex",
  "shorthand",
@@ -1817,19 +1730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
- "web-time",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,24 +1770,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1988,22 +1870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "macro_rules_attribute"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
-dependencies = [
- "macro_rules_attribute-proc_macro",
- "paste",
-]
-
-[[package]]
-name = "macro_rules_attribute-proc_macro"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,12 +1907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,27 +1924,6 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "monostate"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe1be9d0c75642e3e50fedc7ecadf1ef1cbce6eb66462153fc44245343fbee"
-dependencies = [
- "monostate-impl",
- "serde",
-]
-
-[[package]]
-name = "monostate-impl"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c402a4092d5e204f32c9e155431046831fa712637043c58cb73bc6bc6c9663b5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -2157,16 +1996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,12 +2049,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,28 +2068,6 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -2374,12 +2175,6 @@ checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patricia_tree"
@@ -2710,37 +2505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-cond"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059f538b55efd2309c9794130bc149c6a553db90e9d99c2030785c82f0bd7df9"
-dependencies = [
- "either",
- "itertools 0.11.0",
- "rayon",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -3560,18 +3324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spm_precompiled"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
-dependencies = [
- "base64 0.13.1",
- "nom",
- "serde",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "stable-vec"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4084,38 +3836,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokenizers"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3169b3195f925496c895caee7978a335d49218488ef22375267fba5a46a40bd7"
-dependencies = [
- "aho-corasick",
- "derive_builder 0.20.2",
- "esaxx-rs",
- "getrandom 0.2.16",
- "indicatif",
- "itertools 0.13.0",
- "lazy_static",
- "log",
- "macro_rules_attribute",
- "monostate",
- "onig",
- "paste",
- "rand 0.8.5",
- "rayon",
- "rayon-cond",
- "regex",
- "regex-syntax 0.8.5",
- "serde",
- "serde_json",
- "spm_precompiled",
- "thiserror 2.0.12",
- "unicode-normalization-alignments",
- "unicode-segmentation",
- "unicode_categories",
-]
-
-[[package]]
 name = "tokio"
 version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4567,37 +4287,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-normalization-alignments"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "universal-hash"
@@ -4632,12 +4331,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -290,6 +290,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -406,7 +426,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -417,9 +437,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -541,7 +561,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -583,6 +603,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -727,7 +756,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -749,7 +778,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -815,7 +844,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -861,7 +890,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -871,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core 0.20.2",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -880,11 +909,33 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.103",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case 0.7.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -905,6 +956,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
+ "bincode",
  "bollard",
  "cached",
  "chrono",
@@ -912,6 +964,7 @@ dependencies = [
  "clap",
  "derive-new",
  "derive_builder 0.20.2",
+ "derive_more 2.0.1",
  "hex",
  "humantime",
  "humantime-serde",
@@ -922,7 +975,7 @@ dependencies = [
  "rand 0.9.1",
  "redb",
  "regex",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "serenity",
@@ -961,7 +1014,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -999,12 +1052,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1145,7 +1198,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1265,7 +1318,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1274,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1284,7 +1337,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1358,7 +1411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b906521a5b0e6d2ec07ea0bb855d92a1db30b48812744a645a3b2a1405cb8159"
 dependencies = [
  "derive_builder 0.9.0",
- "derive_more",
+ "derive_more 0.99.20",
  "hex",
  "shorthand",
  "stable-vec",
@@ -1489,7 +1542,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1544,7 +1597,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -1754,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -1783,6 +1836,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2020,7 +2084,7 @@ checksum = "c402a4092d5e204f32c9e155431046831fa712637043c58cb73bc6bc6c9663b5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2233,7 +2297,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2244,9 +2308,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.0+3.5.0"
+version = "300.5.1+3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
 dependencies = [
  "cc",
 ]
@@ -2388,7 +2452,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2427,7 +2491,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2562,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2723,7 +2787,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2816,16 +2880,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -2858,7 +2922,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -3096,6 +3160,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,7 +3293,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3250,7 +3326,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3276,16 +3352,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3447,7 +3524,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.1",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "ringbuf",
  "rubato",
  "rusty_pool",
@@ -3520,7 +3597,7 @@ dependencies = [
  "futures-util",
  "hls_m3u8",
  "patricia_tree",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "tokio",
  "tracing",
  "url",
@@ -3778,9 +3855,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3810,7 +3887,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3886,7 +3963,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3897,7 +3974,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "test-case-core",
 ]
 
@@ -3927,7 +4004,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3938,7 +4015,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4040,17 +4117,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -4064,7 +4143,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4203,7 +4282,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4293,7 +4372,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4509,6 +4588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4529,6 +4614,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -4588,7 +4679,7 @@ checksum = "26b682e8c381995ea03130e381928e0e005b7c9eb483c6c8682f50e07b33c2b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4608,6 +4699,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "want"
@@ -4655,7 +4752,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -4690,7 +4787,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4749,14 +4846,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4813,7 +4910,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4824,7 +4921,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4835,9 +4932,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -4890,6 +4987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,11 +5019,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4933,6 +5055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,6 +5071,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4957,10 +5091,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4975,6 +5121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4985,6 +5137,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4999,6 +5157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,6 +5173,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -5064,7 +5234,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -5085,7 +5255,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5105,7 +5275,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -5145,5 +5315,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,14 @@ anyhow = "1.0.86"
 async-trait = "0.1.68"
 axum = "0.8"
 base64 = "0.22.1"
+bincode = "2.0.1"
 bollard = "0.19.1"
 cached = { version = "0.55.1", features = ["async"] }
 chrono = { version = "0.4.25", features = ["serde"] }
 chrono-tz = {version="0.10.3", features=["case-insensitive"]}
 clap = { version = "4.0", features = ["derive"] }
 derive_builder = "0.20.2"
+derive_more = {version="2.0.1", features=["full"]}
 derive-new = "0.7.0"
 hex = "0.4.3"
 humantime = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ cached = { version = "0.55.1", features = ["async"] }
 chrono = { version = "0.4.25", features = ["serde"] }
 chrono-tz = {version="0.10.3", features=["case-insensitive"]}
 clap = { version = "4.0", features = ["derive"] }
-derive_builder = "0.20.2"
 derive_more = {version="2.0.1", features=["full"]}
 derive-new = "0.7.0"
 hex = "0.4.3"
@@ -34,7 +33,6 @@ serde_json = "1.0.85"
 serenity = {default-features = false, features = ["client", "cache", "gateway", "model","rustls_backend","unstable_discord_api", "voice"], version="0.12.2"}
 songbird = {features = ["builtin-queue"], version="0.5.0"}
 symphonia = { features = ["aac", "mp3", "isomp4", "alac"], version = "0.5.2" }
-tokenizers = "=0.21.1"
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = "0.7"
 toml = "0.8"
@@ -43,7 +41,6 @@ tower-http = { version = "0.6", features = ["fs"] }
 tracing = "0.1.36"
 tracing-error = "0.2.1"
 tracing-subscriber = "0.3.15"
-urlencoding = "2.1"
 
 [dependencies.uuid]
 version = "1.1.2"

--- a/src/cmd/dice_roll.rs
+++ b/src/cmd/dice_roll.rs
@@ -104,7 +104,7 @@ impl DiceRoll {
       Some(id) => id,
       None => return Ok(()),
     };
-    let emoji = self.emoji.get(&ctx.http, &ctx.cache, guild_id).await?;
+    let emoji = self.emoji.get(&ctx.http, guild_id).await?;
     let mut response = MessageBuilder::new();
     response
       .push(format!("<@{}>", itx.user.id))

--- a/src/cmd/poll/actor.rs
+++ b/src/cmd/poll/actor.rs
@@ -1,14 +1,15 @@
 use super::{cache::Cache, messages, pollstate::PollState};
 use crate::{
   actor::{Actor, ActorHandle},
-  cmd::poll::NAME,
+  cmd::{poll::NAME, CallContext},
+  emoji::EmojiLookup,
   persistence::PersistentStore,
   shutdown::ShutdownHook,
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serenity::{
-  all::{ChannelId, ComponentInteraction, ComponentInteractionDataKind},
+  all::{ComponentInteraction, ComponentInteractionDataKind, Emoji, GuildId},
   builder::EditMessage,
   prelude::Context,
 };
@@ -20,9 +21,9 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub enum PollMessage {
   UpdateVote(Box<(Uuid, String, Context, ComponentInteraction)>),
-  CreatePoll(Box<(PollState, ChannelId)>),
-  ExpirePoll(Uuid),
-  RestorePolls(Arc<serenity::http::Http>),
+  CreatePoll(Box<(PollState, CallContext)>),
+  ExpirePoll(Uuid, CallContext),
+  RestorePolls(CallContext),
 }
 
 pub struct PollActor {
@@ -30,6 +31,7 @@ pub struct PollActor {
   receiver: Receiver<PollMessage>,
   states: Cache<Uuid, PollState>,
   persistence: Arc<PersistentStore>,
+  emoji: EmojiLookup,
 }
 
 impl PollActor {
@@ -37,12 +39,14 @@ impl PollActor {
     receiver: Receiver<PollMessage>,
     self_ref: ActorHandle<PollMessage>,
     persistence: Arc<PersistentStore>,
+    emoji: EmojiLookup,
   ) -> Box<Self> {
     Box::new(Self {
       self_ref,
       receiver,
       states: Cache::new(),
       persistence,
+      emoji,
     })
   }
 }
@@ -57,19 +61,22 @@ impl Actor<PollMessage> for PollActor {
   async fn handle_msg(&mut self, msg: PollMessage) {
     match msg {
       PollMessage::CreatePoll(boxed_data) => {
-        let (ps, itx) = *boxed_data;
+        let (ps, ctx) = *boxed_data;
         let exp = ps.duration;
-        let exp_key = ps.id;
+        let exp_key = *ps.id;
 
         // Save to persistence first
         if let Err(e) = self.persistence.polls().save(&ps.id, &ps) {
-          error!("Failed to persist poll {}: {}", ps.id, e);
+          error!("Failed to persist poll {}: {}", *ps.id, e);
         }
 
-        if let Err(e) = messages::send_poll_message(&ps, &itx)
+        let Some(emoji) = get_emoji(&self.emoji, Some(*ps.guild), &ctx).await else {
+          return;
+        };
+        if let Err(e) = messages::send_poll_message(&ps, &ctx, &emoji)
           .await
           .map_err(|e| anyhow!("{}", e))
-          .and_then(|_| self.states.insert(ps.id, ps))
+          .and_then(|_| self.states.insert(*ps.id, ps))
         {
           error!("Failed to launch poll {}", e);
           return;
@@ -78,22 +85,22 @@ impl Actor<PollMessage> for PollActor {
         let hdl = self.self_ref.clone();
         tokio::spawn(async move {
           tokio::time::sleep(exp).await;
-          hdl.send(PollMessage::ExpirePoll(exp_key)).await
+          hdl.send(PollMessage::ExpirePoll(exp_key, ctx)).await
         });
       }
-      PollMessage::ExpirePoll(id) => {
-        let (resp, ctx) = match self
-          .states
-          .invoke(&id, |p| (messages::build_exp_message(p), p.ctx.clone()))
-        {
+      PollMessage::ExpirePoll(id, ctx) => {
+        let ps = match self.states.invoke(&id, |p| p.clone()) {
           Err(e) => {
             error!("Failed to inform channel poll has finished: {}", e);
             return;
           }
           Ok(v) => v,
         };
-
-        let _ = ctx.channel.say(&ctx.http, resp).await;
+        let Some(emoji) = get_emoji(&self.emoji, Some(*ps.guild), &ctx).await else {
+          return;
+        };
+        let resp = messages::build_exp_message(&ps, &emoji);
+        let _ = ps.channel.say(&ctx.http, resp).await;
 
         if let Err(e) = self.states.remove(&id) {
           warn!("Failed to reap poll on exp: {}", e);
@@ -115,6 +122,12 @@ impl Actor<PollMessage> for PollActor {
             return;
           }
         };
+        let call_ctx = CallContext {
+          http: ctx.http.clone(),
+        };
+        let Some(emoji) = get_emoji(&self.emoji, mtx.guild_id, &call_ctx).await else {
+          return;
+        };
         let new_body = match self
           .states
           .contains_key(&id)
@@ -134,7 +147,9 @@ impl Actor<PollMessage> for PollActor {
             {
               warn!("Failed to persist vote update for poll {}: {}", id, e);
             }
-            self.states.invoke(&id, messages::build_poll_message)
+            self
+              .states
+              .invoke(&id, |ps| messages::build_poll_message(ps, &emoji))
           }) {
           Ok(v) => v,
           Err(e) => {
@@ -157,34 +172,32 @@ impl Actor<PollMessage> for PollActor {
           error!("Failed to defer the interaction: {}", e);
         }
       }
-      PollMessage::RestorePolls(http) => {
+      PollMessage::RestorePolls(ctx) => {
         if let Err(e) = self.persistence.polls().cleanup_expired() {
           warn!("Failed to clean up expired poll from persistence: {}", e);
         }
         match self.persistence.polls().load_all() {
           Ok(polls) => {
-            for (_, mut poll) in polls {
-              // Restore the Http client that was skipped during serialization
-              poll.ctx.http = http.clone();
-
+            for (_, poll) in polls {
               // Restore to in-memory cache
-              let poll_id = poll.id;
-              if let Err(e) = self.states.insert(poll.id, poll.clone()) {
+              let poll_id = *poll.id;
+              if let Err(e) = self.states.insert(*poll.id, poll.clone()) {
                 panic!("Failed to restore poll {} to cache: {}", poll_id, e);
               }
 
               // Set up expiry timer for remaining duration using checked arithmetic
               let remaining_duration = poll.duration - poll.elapsed();
-              let exp_key = poll.id;
+              let exp_key = *poll.id;
               let hdl = self.self_ref.clone();
+              let nw_ctx = ctx.clone();
               tokio::spawn(async move {
                 tokio::time::sleep(remaining_duration).await;
-                hdl.send(PollMessage::ExpirePoll(exp_key)).await
+                hdl.send(PollMessage::ExpirePoll(exp_key, nw_ctx)).await
               });
 
               info!(
                 "Restored poll {} with {} remaining",
-                poll.id,
+                *poll.id,
                 humantime::format_duration(remaining_duration)
               );
             }
@@ -198,12 +211,37 @@ impl Actor<PollMessage> for PollActor {
   }
 }
 
+async fn get_emoji(
+  emoji: &EmojiLookup,
+  maybe_guild: Option<GuildId>,
+  ctx: &CallContext,
+) -> Option<Emoji> {
+  let emoji_res = maybe_guild
+    .ok_or(anyhow!("Missing guild_id from interaction"))
+    .map(|gid| emoji.get(&ctx.http, gid));
+  let emoji_res = match emoji_res {
+    Ok(me) => me.await,
+    Err(e) => {
+      error!("Failed to get emoji {}", e);
+      return None;
+    }
+  };
+  match emoji_res {
+    Ok(me) => Some(me),
+    Err(e) => {
+      error!("Failed to get emoji {}", e);
+      None
+    }
+  }
+}
+
 #[async_trait]
 impl ShutdownHook for PollActor {
   #[instrument(name=NAME, level="INFO", skip(self))]
   async fn shutdown(&self) -> Result<()> {
     info!("Shutting down");
     self.states.iter(|id, poll| {
+      info!("Saving poll {}", id);
       if let Err(e) = self.persistence.polls().save(id, poll) {
         error!("Failed to save poll {} during shutdown: {}", id, e)
       }

--- a/src/cmd/poll/messages.rs
+++ b/src/cmd/poll/messages.rs
@@ -1,13 +1,16 @@
 use serenity::{
+  all::Emoji,
   builder::{CreateMessage, CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption},
-  model::prelude::{ChannelId, ReactionType},
+  model::prelude::ReactionType,
   utils::MessageBuilder,
 };
+
+use crate::cmd::CallContext;
 
 use super::pollstate::PollState;
 use humantime::format_duration;
 
-pub fn build_poll_message(ps: &PollState) -> String {
+pub fn build_poll_message(ps: &PollState, emoji: &Emoji) -> String {
   let mut bar_vec = ps
     .votes
     .iter()
@@ -45,9 +48,9 @@ pub fn build_poll_message(ps: &PollState) -> String {
   voter_vec.sort();
 
   MessageBuilder::new()
-    .emoji(&ps.ctx.emoji)
+    .emoji(emoji)
     .push_underline("Roommate Poll, Bobby, Roommate Poll!")
-    .emoji(&ps.ctx.emoji)
+    .emoji(emoji)
     .push_line("")
     .push_line("")
     .push_bold(&ps.topic)
@@ -64,12 +67,16 @@ pub fn build_poll_message(ps: &PollState) -> String {
     .build()
 }
 
-pub async fn send_poll_message(ps: &PollState, itx: &ChannelId) -> serenity::Result<()> {
-  itx
+pub async fn send_poll_message(
+  ps: &PollState,
+  ctx: &CallContext,
+  emoji: &Emoji,
+) -> serenity::Result<()> {
+  ps.channel
     .send_message(
-      &ps.ctx.http,
+      &ctx.http,
       CreateMessage::new()
-        .content(build_poll_message(ps))
+        .content(build_poll_message(ps, emoji))
         .select_menu(
           CreateSelectMenu::new(
             ps.id.to_string(),
@@ -82,7 +89,7 @@ pub async fn send_poll_message(ps: &PollState, itx: &ChannelId) -> serenity::Res
                     ReactionType::Custom {
                       name: None,
                       animated: false,
-                      id: ps.ctx.emoji.id,
+                      id: emoji.id,
                     },
                   )
                 })
@@ -99,7 +106,7 @@ pub async fn send_poll_message(ps: &PollState, itx: &ChannelId) -> serenity::Res
     .map(|_| ())
 }
 
-pub fn build_exp_message(ps: &PollState) -> String {
+pub fn build_exp_message(ps: &PollState, emoji: &Emoji) -> String {
   let winner = ps
     .votes
     .values()
@@ -108,9 +115,9 @@ pub fn build_exp_message(ps: &PollState) -> String {
     .unwrap_or_else(|| "<Error Poll Had No Options?>".to_string());
 
   MessageBuilder::new()
-    .emoji(&ps.ctx.emoji)
+    .emoji(emoji)
     .push_underline("The Vote has Ended!")
-    .emoji(&ps.ctx.emoji)
+    .emoji(emoji)
     .push_line("")
     .push_line("")
     .push("The winner of \"")

--- a/src/cmd/ready.rs
+++ b/src/cmd/ready.rs
@@ -1,5 +1,5 @@
 use super::{check_in::CheckInMessage, poll::PollMessage};
-use crate::actor::ActorHandle;
+use crate::{actor::ActorHandle, cmd::CallContext};
 use derive_new::new;
 use serenity::{model::gateway::Ready, prelude::Context};
 use tracing::{info, instrument};
@@ -18,16 +18,20 @@ impl ReadyHandler {
     // Restore persisted polls and check-in configurations
     info!("Restoring persistent state...");
 
+    let cctx = CallContext {
+      http: ctx.http.clone(),
+    };
+
     // Restore polls
     self
       .poll_handle
-      .send(PollMessage::RestorePolls(ctx.http.clone()))
+      .send(PollMessage::RestorePolls(cctx.clone()))
       .await;
 
     // Restore check-in
     self
       .checkin_handle
-      .send(CheckInMessage::RestoreConfig(ctx.http.clone()))
+      .send(CheckInMessage::RestoreConfig(cctx))
       .await;
   }
 }

--- a/src/cmd/server/ip.rs
+++ b/src/cmd/server/ip.rs
@@ -60,7 +60,7 @@ impl SubCommandHandler for Ip {
       return Ok(());
     };
 
-    let emoji = self.emoji.get(&ctx.http, &ctx.cache, guild_id).await?;
+    let emoji = self.emoji.get(&ctx.http, guild_id).await?;
     let mut build = MessageBuilder::new();
     build
       .push_bold("Ya boi shruggin at ")

--- a/src/cmd/shrug.rs
+++ b/src/cmd/shrug.rs
@@ -66,7 +66,7 @@ impl MessageListener for ShrugHandler {
       return Ok(());
     }
 
-    let emoji = self.emoji.get(&ctx.http, &ctx.cache, guild_id).await?;
+    let emoji = self.emoji.get(&ctx.http, guild_id).await?;
     self.react_and_send(emoji, ctx, msg).await
   }
 }

--- a/src/cmd/voice/play.rs
+++ b/src/cmd/voice/play.rs
@@ -104,7 +104,7 @@ async fn wrapped_handle(
         .send(DisconnectMessage::Details(DisconnectDetails::new(
           handler_lock.clone(),
           ctx.http.clone(),
-          play.emoji.get(&ctx.http, &ctx.cache, guild_id).await?,
+          play.emoji.get(&ctx.http, guild_id).await?,
         )))
         .await;
 
@@ -162,7 +162,7 @@ async fn wrapped_handle(
   );
   let _th = handler.enqueue(track_with_data).await;
 
-  let emoji = play.emoji.get(&ctx.http, &ctx.cache, guild_id).await?;
+  let emoji = play.emoji.get(&ctx.http, guild_id).await?;
   let mut build = MessageBuilder::new();
   build
     .push_bold("Queued")

--- a/src/cmd/voice/reorder.rs
+++ b/src/cmd/voice/reorder.rs
@@ -53,7 +53,7 @@ impl SubCommandHandler for Reorder {
       }
     });
 
-    let emoji = self.emoji.get(&ctx.http, &ctx.cache, guild_id).await?;
+    let emoji = self.emoji.get(&ctx.http, guild_id).await?;
     itx
       .edit_response(
         &ctx.http,

--- a/src/cmd/voice/skip.rs
+++ b/src/cmd/voice/skip.rs
@@ -29,7 +29,7 @@ impl SubCommandHandler for Skip {
       .expect("Songbird Voice client placed in at initialisation.")
       .clone();
 
-    let emoji = self.emoji.get(&ctx.http, &ctx.cache, guild_id).await?;
+    let emoji = self.emoji.get(&ctx.http, guild_id).await?;
 
     let handler_lock = manager
       .get(guild_id)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod env;
 mod logging;
 mod persistence;
 mod shutdown;
+mod types;
 mod web;
 
 use clap::Parser;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,98 @@
+use bincode::{impl_borrow_decode, Decode, Encode};
+use chrono::{NaiveTime, Timelike};
+use derive_more::{Deref, Display};
+use serenity::{
+  all::{EmojiId, GuildId, RoleId},
+  model::prelude::ChannelId,
+};
+use uuid::Uuid;
+
+macro_rules! impl_encode {
+  ($name:ident, |$this:ident| $inner:expr) => {
+    impl Encode for $name {
+      fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+      ) -> Result<(), bincode::error::EncodeError> {
+        bincode::Encode::encode(&(|$this: &$name| $inner)(self), encoder)
+      }
+    }
+  };
+}
+
+macro_rules! impl_decode {
+  ($name:ident, |$this:ident| $inner:expr) => {
+    impl<Context> Decode<Context> for $name {
+      fn decode<D: bincode::de::Decoder<Context = Context>>(
+        decoder: &mut D,
+      ) -> Result<Self, bincode::error::DecodeError> {
+        Ok($name((|$this| $inner)(bincode::Decode::decode(decoder)?)))
+      }
+    }
+  };
+}
+
+// Formats: https://discord.com/developers/docs/reference#message-formatting
+
+#[derive(Clone, Deref, Display)]
+#[display("<#{_0}>")]
+pub struct Chan(pub ChannelId);
+impl_encode!(Chan, |s| s.0.get());
+impl_decode!(Chan, |d| ChannelId::new(d));
+impl_borrow_decode!(Chan);
+
+#[derive(Clone, Deref)]
+pub struct Guil(pub GuildId);
+impl_encode!(Guil, |s| s.0.get());
+impl_decode!(Guil, |d| GuildId::new(d));
+impl_borrow_decode!(Guil);
+
+#[derive(Clone, Deref, Display)]
+#[display("<&@{_0}>")]
+pub struct Rol(pub RoleId);
+impl_encode!(Rol, |s| s.0.get());
+impl_decode!(Rol, |d| RoleId::new(d));
+impl_borrow_decode!(Rol);
+
+#[derive(Clone, Deref)]
+pub struct Emoj(pub EmojiId);
+impl_encode!(Emoj, |s| s.0.get());
+impl_decode!(Emoj, |d| EmojiId::new(d));
+impl_borrow_decode!(Emoj);
+
+#[derive(Clone, Deref)]
+pub struct NaiveT(pub NaiveTime);
+
+#[derive(Clone, Debug, Deref, PartialEq, Eq)]
+pub struct Pid(pub Uuid);
+impl_encode!(Pid, |s| s.0.into_bytes());
+impl_decode!(Pid, |d| Uuid::from_bytes(d));
+impl_borrow_decode!(Pid);
+
+impl Encode for NaiveT {
+  fn encode<E: bincode::enc::Encoder>(
+    &self,
+    encoder: &mut E,
+  ) -> Result<(), bincode::error::EncodeError> {
+    bincode::Encode::encode(&self.0.num_seconds_from_midnight(), encoder)?;
+    bincode::Encode::encode(&self.0.nanosecond(), encoder)?;
+    Ok(())
+  }
+}
+impl<Context> Decode<Context> for NaiveT {
+  fn decode<D: bincode::de::Decoder<Context = Context>>(
+    decoder: &mut D,
+  ) -> Result<Self, bincode::error::DecodeError> {
+    let secs: u32 = bincode::Decode::decode(decoder)?;
+    let nanos: u32 = bincode::Decode::decode(decoder)?;
+    Ok(NaiveT(
+      NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos).ok_or(
+        bincode::error::DecodeError::InvalidDuration {
+          secs: secs.into(),
+          nanos,
+        },
+      )?,
+    ))
+  }
+}
+impl_borrow_decode!(NaiveT);

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -1,3 +1,8 @@
+use crate::web::templates;
+use crate::{
+  config::{Config, FormData},
+  persistence::PersistentStore,
+};
 use axum::{
   extract::{Extension, Form, Query},
   http::{header, StatusCode},
@@ -5,12 +10,6 @@ use axum::{
 };
 use humantime::parse_duration;
 use std::{collections::HashMap, sync::Arc};
-
-use crate::web::templates;
-use crate::{
-  config::{Config, FormData},
-  persistence::PersistentStore,
-};
 
 // Helper function to get config or return default
 fn get_config_or_default() -> Config {


### PR DESCRIPTION
Swap to Bincode based serialization to improve read/write speeds over `serde_json`. Bincode wasn't selected for many other reasons than being simple and fast. The only downside was many types didn't have a bincode derive setup already, so new types needed to be introduced (serde mode wasn't compatible for bincode)
